### PR TITLE
Rename Python files and update wrappers

### DIFF
--- a/src/jt
+++ b/src/jt
@@ -8,33 +8,34 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(dirname "$0")"
 COMMAND="$1"
 shift
 
 case "$COMMAND" in
   add)
-    exec jt-add "$@"
+    exec python3 "$SCRIPT_DIR/jt-add.py" "$@"
     ;;
   ls)
-    exec jt-ls "$@"
+    exec python3 "$SCRIPT_DIR/jt-ls.py" "$@"
     ;;
   rm)
-    exec jt-rm "$@"
+    exec python3 "$SCRIPT_DIR/jt-rm.py" "$@"
     ;;
   rename)
-    exec jt-rename "$@"
+    exec python3 "$SCRIPT_DIR/jt-rename.py" "$@"
     ;;
   nav)
-    exec jt-nav "$@"
+    exec python3 "$SCRIPT_DIR/jt-nav.py" "$@"
     ;;
   box)
-    exec jt-box
+    exec python3 "$SCRIPT_DIR/jt-box.py"
     ;;
   append)
-    exec jt-append
+    exec python3 "$SCRIPT_DIR/jt-append.py"
     ;;
   tags)
-    exec jt-tags "$@"
+    exec "$SCRIPT_DIR/jt-tags" "$@"
     ;;
   *)
     echo "Unknown command: $COMMAND. Use one of: add, ls, rm, rename, nav, box, append, tags." >&2

--- a/src/jt-add.py
+++ b/src/jt-add.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-append.py
+++ b/src/jt-append.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-box.py
+++ b/src/jt-box.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import json
 import re

--- a/src/jt-ls.py
+++ b/src/jt-ls.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-nav.py
+++ b/src/jt-nav.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-rename.py
+++ b/src/jt-rename.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-rm.py
+++ b/src/jt-rm.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-tags
+++ b/src/jt-tags
@@ -8,24 +8,25 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(dirname "$0")"
 SUB="$1"
 shift
 
 case "$SUB" in
   add)
-    exec jt-tags-add "$@"
+    exec python3 "$SCRIPT_DIR/jt-tags-add.py" "$@"
     ;;
   rm)
-    exec jt-tags-rm "$@"
+    exec python3 "$SCRIPT_DIR/jt-tags-rm.py" "$@"
     ;;
   list)
-    exec jt-tags-list "$@"
+    exec python3 "$SCRIPT_DIR/jt-tags-list.py" "$@"
     ;;
   rename)
-    exec jt-tags-rename "$@"
+    exec python3 "$SCRIPT_DIR/jt-tags-rename.py" "$@"
     ;;
   mv)
-    exec jt-tags-mv "$@"
+    exec python3 "$SCRIPT_DIR/jt-tags-mv.py" "$@"
     ;;
   *)
     echo "Unknown jt-tags command: $SUB. Use one of: add, rm, list, rename, mv." >&2

--- a/src/jt-tags-add.py
+++ b/src/jt-tags-add.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-tags-list.py
+++ b/src/jt-tags-list.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-tags-mv.py
+++ b/src/jt-tags-mv.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-tags-rename.py
+++ b/src/jt-tags-rename.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json

--- a/src/jt-tags-rm.py
+++ b/src/jt-tags-rm.py
@@ -1,4 +1,3 @@
-#!/home/jaguar/.pyenv/versions/3.13.3/envs/jdex/bin/python
 import os
 import sys
 import json


### PR DESCRIPTION
## Summary
- rename Python scripts in `src` with `.py` extensions
- remove Python shebangs
- update wrapper scripts to execute new `.py` files via `python3`

## Testing
- `python3 -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6841441e53f4832ca87d69eb29b53dac