### PR TITLE
Move scripts to bin directory

### DIFF
--- a/bin/jt
+++ b/bin/jt
@@ -14,25 +14,25 @@ shift
 
 case "$COMMAND" in
   add)
-    exec python3 "$SCRIPT_DIR/jt-add.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-add.py" "$@"
     ;;
   ls)
-    exec python3 "$SCRIPT_DIR/jt-ls.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-ls.py" "$@"
     ;;
   rm)
-    exec python3 "$SCRIPT_DIR/jt-rm.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-rm.py" "$@"
     ;;
   rename)
-    exec python3 "$SCRIPT_DIR/jt-rename.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-rename.py" "$@"
     ;;
   nav)
-    exec python3 "$SCRIPT_DIR/jt-nav.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-nav.py" "$@"
     ;;
   box)
-    exec python3 "$SCRIPT_DIR/jt-box.py"
+    exec python3 "$SCRIPT_DIR/../src/jt-box.py"
     ;;
   append)
-    exec python3 "$SCRIPT_DIR/jt-append.py"
+    exec python3 "$SCRIPT_DIR/../src/jt-append.py"
     ;;
   tags)
     exec "$SCRIPT_DIR/jt-tags" "$@"

--- a/bin/jt-tags
+++ b/bin/jt-tags
@@ -14,19 +14,19 @@ shift
 
 case "$SUB" in
   add)
-    exec python3 "$SCRIPT_DIR/jt-tags-add.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-tags-add.py" "$@"
     ;;
   rm)
-    exec python3 "$SCRIPT_DIR/jt-tags-rm.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-tags-rm.py" "$@"
     ;;
   list)
-    exec python3 "$SCRIPT_DIR/jt-tags-list.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-tags-list.py" "$@"
     ;;
   rename)
-    exec python3 "$SCRIPT_DIR/jt-tags-rename.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-tags-rename.py" "$@"
     ;;
   mv)
-    exec python3 "$SCRIPT_DIR/jt-tags-mv.py" "$@"
+    exec python3 "$SCRIPT_DIR/../src/jt-tags-mv.py" "$@"
     ;;
   *)
     echo "Unknown jt-tags command: $SUB. Use one of: add, rm, list, rename, mv." >&2


### PR DESCRIPTION
## Summary
- move top-level `jt` and `jt-tags` scripts from `src` to `bin`
- update script paths so they continue to reference supporting modules in `src`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414616aafc832ca1b303e2b8d61e16